### PR TITLE
using nodejs base ami

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - install-nodejs
+ # - install-nodejs
   - npm-stop
   - s3-deploy-object
   - unarchive-cleanup


### PR DESCRIPTION
No need to install nodejs since the base ami already is nodejs, hence commenting out.